### PR TITLE
Typos: 2015-08-10-switching-to-generators.md

### DIFF
--- a/_posts/2015/2015-08-10-switching-to-generators.md
+++ b/_posts/2015/2015-08-10-switching-to-generators.md
@@ -37,7 +37,7 @@ function getArticles() {
 ?>
 ```
 
-The preceeding example is a faily common pattern in CRUD application. In the
+The preceding example is a fairly common pattern in CRUD application. In the
 example, we're fetching a list of records from the database, and we apply
 some function to the records before returning them.
 


### PR DESCRIPTION
Fix a couple of typos

 * preceeding -> preceding
 * faily -> fairly