### PR TITLE
Fixes resume link

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ layout: default
 
 <section class="hireme">
     Looking for a PHP developer for your next project? I'm looking for work!
-    Check out my <a href="/resume.html">resume</a> or <a href="mailto:work@evertpot.com">drop me a line!</a>
+    Check out my <a href="/resume">resume</a> or <a href="mailto:work@evertpot.com">drop me a line!</a>
 </section>
 
 <section class="respond">


### PR DESCRIPTION
Presumably `resume.html` was the correct place to link to on a previous version of the site.