### PR TITLE
Update stylesheet so that text actually contrasts background.

### DIFF
--- a/_includes/css/stylesheet.css
+++ b/_includes/css/stylesheet.css
@@ -15,6 +15,7 @@ body {
     display: flex;
     flex-direction: column;
     font-size: 120%;
+    color: black;
 }
 
 @media (max-width: 512px) {


### PR DESCRIPTION
Sorry, I was just finding it very difficult to read your github page in my browser.

For some reason the text just blends directly into the background.

![image](https://user-images.githubusercontent.com/8430304/71699202-629d5f80-2db6-11ea-906b-a2a91aeb5622.png)


With this PR specifying the colour.

![image](https://user-images.githubusercontent.com/8430304/71699232-7d6fd400-2db6-11ea-9d1b-08f1c4064814.png)


This is on Firefox 72 on Linux with the feature browser.display.use_system_colour set to true. Obviously this is a little non-standard build but I think it's still right to perhaps specify text colour anyway.